### PR TITLE
Remove github token from the input parameter

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -4,16 +4,12 @@ name: CI Status
 description: 'Action for checking the CI status and notifying it to the maintainer'
 
 inputs:
-  github_token:
-    description: Github token
-    required: true
   email_token:
-    description: Email token
+    description: Email secret
     required: true
 
 runs:
   using: 'docker'
   image: 'Dockerfile'
   env:
-    GITHUB_TOKEN: ${{ inputs.github_token }}
     EMAIL_TOKEN: ${{ inputs.email_token }}


### PR DESCRIPTION
Github provides the environment variable for GITHUB_TOKEN by default and
no need to provide via secrets.